### PR TITLE
2322 integration tests on circleci -> Master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,8 +92,8 @@ jobs:
       - run: npm install -g newman
       - run: newman run -h
       # Add the required hostname entries for the integration tests.
-      - run: echo "127.0.0.1 a3s-identity-server" >> /etc/hosts
-      - run: echo "127.0.0.1 open-ldap" >> /etc/hosts
+      - run: sudo echo "127.0.0.1 a3s-identity-server" >> /etc/hosts
+      - run: sudo echo "127.0.0.1 open-ldap" >> /etc/hosts
       # Checkout the repository
       - checkout
       # # Build the two required docker images into the local docker image repo from this version of the code.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,12 +45,6 @@ jobs:
     working_directory: ~/build
     
     steps:
-      # Update, upgrade, then install  openssh and git for a clean checkout
-      # Im not sure that these components are required.
-      # - run: apk update
-      # - run: apk upgrade
-      # - run: apk --no-cache add --update git openssh
-
       - checkout
       - run: dotnet restore
       - run: dotnet build
@@ -207,23 +201,18 @@ workflows:
       - vulnerability-test: *only-tags
       - license-headers: *only-tags
       - fossa-scan: *only-tags
-      #- postman-integration-tests
+      - postman-integration-tests: *only-tags
       - a3s-docker-build-push:
           requires:
           - unit-test
           - static-analysis
           - license-headers
-          #- postman-integration-tests
+          - postman-integration-tests
           <<: *only-tags
-            # branches:
-            #   only: master
       - a3s-ids4-docker-build-push:
           requires:
           - unit-test
           - static-analysis
           - license-headers
-          #- postman-integration-tests
+          - postman-integration-tests
           <<: *only-tags
-            # We only want to build images when release tags are created. Uncomment the below to run on master branch updates too.
-            # branches:
-            #   only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,9 @@ jobs:
     # Use a Linux VM instead of docker environment. This is crucial for successful mounting of file systems into docker containers.
     # Note: Not specifying an image (for the machine) results in the circleci:classic image being pulled in. This contains docker-compose on it already.
     machine: true
-      hosts:
-        a3s-identity-servert: 127.0.0.1
-        open-ldap: 127.0.0.1
+    hosts:
+      a3s-identity-servert: 127.0.0.1
+      open-ldap: 127.0.0.1
     working_directory: ~/repo
     steps:
       # Install NPM.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,14 +91,22 @@ jobs:
       # Install Newman Using NPM
       - run: npm install -g newman
       - run: newman run -h
-      # - checkout
+      # Checkout the repository
+      - checkout
       # # Build the two required docker images into the local docker image repo from this version of the code.
-      # - run: docker build -t grindrodbank/a3s:latest -f ~/repo/a3s-Dockerfile ~/repo
-      # - run: docker build -t grindrodbank/a3s-identity-server:latest -f ~/repo/a3s-identity-server-Dockerfile ~/repo
+      - run: docker build -t grindrodbank/a3s:latest -f ~/repo/a3s-Dockerfile ~/repo
+      - run: docker build -t grindrodbank/a3s-identity-server:latest -f ~/repo/a3s-identity-server-Dockerfile ~/repo
       # # Start the quickstart instance, as it models a fully featured running A3S environment, which is ideal for running Postman tests against.
-      # - run: docker-compose -f ~/repo/quickstart/docker-compose.yml up -d
-      # - run: sleep 15
+      - run: docker-compose -f ~/repo/quickstart/docker-compose.yml up -d
+      - run: sleep 15
+      # Run docker-compose up -d again to hopefully mitigate any container ordering issues.
+      - run: docker-compose -f ~/repo/quickstart/docker-compose.yml up -d
+      - run: sleep 10
       # # Run the Newman orb to execute the collection against the quickstart environment.
+      - run: newman \
+             run ~/repo/postman/A3S-pipeline.postman_collection.json \
+                -r cli \
+                -e ~/repo/postman/A3S-quickstart.postman_environment.json
       # - newman/newman-run:
       #     collection: "~/repo/postman/A3S-pipeline.postman_collection.json"
       #     environment: "~/repo/postman/A3S-quickstart.postman_environment.json"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,6 @@ jobs:
     # Use a Linux VM instead of docker environment. This is crucial for successful mounting of file systems into docker containers.
     # Note: Not specifying an image (for the machine) results in the circleci:classic image being pulled in. This contains docker-compose on it already.
     machine: true
-    # hosts:
-    #   a3s-identity-servert: 127.0.0.1
-    #   open-ldap: 127.0.0.1
     working_directory: ~/repo
     steps:
       # Install NPM.
@@ -91,8 +88,6 @@ jobs:
       # Add the required hostname entries for the integration tests.
       - run: echo 127.0.0.1 a3s-identity-server | sudo tee -a /etc/hosts
       - run: echo 127.0.0.1 open-ldap | sudo tee -a /etc/hosts
-      # - run: sudo echo "127.0.0.1 a3s-identity-server" >> /etc/hosts
-      # - run: sudo echo "127.0.0.1 open-ldap" >> /etc/hosts
       # Checkout the repository
       - checkout
       # # Build the two required docker images into the local docker image repo from this version of the code.
@@ -106,9 +101,6 @@ jobs:
       - run: sleep 5
       # # Run the Newman orb to execute the collection against the quickstart environment.
       - run: newman run ~/repo/postman/A3S-pipeline.postman_collection.json -r cli -e ~/repo/postman/A3S-quickstart.postman_environment.json
-      # - newman/newman-run:
-      #     collection: "~/repo/postman/A3S-pipeline.postman_collection.json"
-      #     environment: "~/repo/postman/A3S-quickstart.postman_environment.json"
 
   a3s-docker-build-push:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,9 @@ jobs:
       # Install Newman Using NPM
       - run: npm install -g newman
       - run: newman run -h
+      # Add the required hostname entries for the integration tests.
+      - run: echo "127.0.0.1 a3s-identity-server" >> /etc/hosts
+      - run: echo "127.0.0.1 open-ldap" >> /etc/hosts
       # Checkout the repository
       - checkout
       # # Build the two required docker images into the local docker image repo from this version of the code.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,10 +106,10 @@ jobs:
       - run: docker build -t grindrodbank/a3s-identity-server:latest -f ~/repo/a3s-identity-server-Dockerfile ~/repo
       # # Start the quickstart instance, as it models a fully featured running A3S environment, which is ideal for running Postman tests against.
       - run: docker-compose -f ~/repo/quickstart/docker-compose.yml up -d
-      - run: sleep 15
+      - run: sleep 5
       # Run docker-compose up -d again to hopefully mitigate any container ordering issues.
       - run: docker-compose -f ~/repo/quickstart/docker-compose.yml up -d
-      - run: sleep 10
+      - run: sleep 5
       # # Run the Newman orb to execute the collection against the quickstart environment.
       - run: newman run ~/repo/postman/A3S-pipeline.postman_collection.json -r cli -e ~/repo/postman/A3S-quickstart.postman_environment.json
       # - newman/newman-run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,17 +85,20 @@ jobs:
     machine: true 
     working_directory: ~/repo
     steps:
-      - checkout
-      # Build the two required docker images into the local docker image repo from this version of the code.
-      - run: docker build -t grindrodbank/a3s:latest -f ~/repo/a3s-Dockerfile ~/repo
-      - run: docker build -t grindrodbank/a3s-identity-server:latest -f ~/repo/a3s-identity-server-Dockerfile ~/repo
-      # Start the quickstart instance, as it models a fully featured running A3S environment, which is ideal for running Postman tests against.
-      - run: docker-compose -f ~/repo/quickstart/docker-compose.yml up -d
-      - run: sleep 15
-      # Run the Newman orb to execute the collection against the quickstart environment.
-      - newman/newman-run:
-          collection: "~/repo/postman/A3S-pipeline.postman_collection.json"
-          environment: "~/repo/postman/A3S-quickstart.postman_environment.json"
+      # Install NPM.
+      - run: curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+      - run: sudo apt install nodejs
+      # - checkout
+      # # Build the two required docker images into the local docker image repo from this version of the code.
+      # - run: docker build -t grindrodbank/a3s:latest -f ~/repo/a3s-Dockerfile ~/repo
+      # - run: docker build -t grindrodbank/a3s-identity-server:latest -f ~/repo/a3s-identity-server-Dockerfile ~/repo
+      # # Start the quickstart instance, as it models a fully featured running A3S environment, which is ideal for running Postman tests against.
+      # - run: docker-compose -f ~/repo/quickstart/docker-compose.yml up -d
+      # - run: sleep 15
+      # # Run the Newman orb to execute the collection against the quickstart environment.
+      # - newman/newman-run:
+      #     collection: "~/repo/postman/A3S-pipeline.postman_collection.json"
+      #     environment: "~/repo/postman/A3S-quickstart.postman_environment.json"
 
   a3s-docker-build-push:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,10 +111,7 @@ jobs:
       - run: docker-compose -f ~/repo/quickstart/docker-compose.yml up -d
       - run: sleep 10
       # # Run the Newman orb to execute the collection against the quickstart environment.
-      - run: newman \
-             run ~/repo/postman/A3S-pipeline.postman_collection.json \
-                -r cli \
-                -e ~/repo/postman/A3S-quickstart.postman_environment.json
+      - run: newman run ~/repo/postman/A3S-pipeline.postman_collection.json -r cli -e ~/repo/postman/A3S-quickstart.postman_environment.json
       # - newman/newman-run:
       #     collection: "~/repo/postman/A3S-pipeline.postman_collection.json"
       #     environment: "~/repo/postman/A3S-quickstart.postman_environment.json"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,9 @@ jobs:
     # Use a Linux VM instead of docker environment. This is crucial for successful mounting of file systems into docker containers.
     # Note: Not specifying an image (for the machine) results in the circleci:classic image being pulled in. This contains docker-compose on it already.
     machine: true
-    hosts:
-      a3s-identity-servert: 127.0.0.1
-      open-ldap: 127.0.0.1
+    # hosts:
+    #   a3s-identity-servert: 127.0.0.1
+    #   open-ldap: 127.0.0.1
     working_directory: ~/repo
     steps:
       # Install NPM.
@@ -95,6 +95,8 @@ jobs:
       - run: npm install -g newman
       - run: newman run -h
       # Add the required hostname entries for the integration tests.
+      - run: echo 127.0.0.1 a3s-identity-server | sudo tee -a /etc/hosts
+      - run: echo 127.0.0.1 open-ldap | sudo tee -a /etc/hosts
       # - run: sudo echo "127.0.0.1 a3s-identity-server" >> /etc/hosts
       # - run: sudo echo "127.0.0.1 open-ldap" >> /etc/hosts
       # Checkout the repository

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,9 @@ jobs:
       # Install NPM.
       - run: curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
       - run: sudo apt install nodejs
+      # Install Newman Using NPM
+      - run: npm install -g newman
+      - run: newman run -h
       # - checkout
       # # Build the two required docker images into the local docker image repo from this version of the code.
       # - run: docker build -t grindrodbank/a3s:latest -f ~/repo/a3s-Dockerfile ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ workflows:
       - static-analysis
       - vulnerability-test
       - license-headers
+      - postman-integration-tests
       - fossa-scan:
           filters:    
             branches:    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,10 @@ jobs:
   postman-integration-tests:
     # Use a Linux VM instead of docker environment. This is crucial for successful mounting of file systems into docker containers.
     # Note: Not specifying an image (for the machine) results in the circleci:classic image being pulled in. This contains docker-compose on it already.
-    machine: true 
+    machine: true
+      hosts:
+        a3s-identity-servert: 127.0.0.1
+        open-ldap: 127.0.0.1
     working_directory: ~/repo
     steps:
       # Install NPM.
@@ -92,8 +95,8 @@ jobs:
       - run: npm install -g newman
       - run: newman run -h
       # Add the required hostname entries for the integration tests.
-      - run: sudo echo "127.0.0.1 a3s-identity-server" >> /etc/hosts
-      - run: sudo echo "127.0.0.1 open-ldap" >> /etc/hosts
+      # - run: sudo echo "127.0.0.1 a3s-identity-server" >> /etc/hosts
+      # - run: sudo echo "127.0.0.1 open-ldap" >> /etc/hosts
       # Checkout the repository
       - checkout
       # # Build the two required docker images into the local docker image repo from this version of the code.

--- a/postman/A3S-pipeline.postman_collection.json
+++ b/postman/A3S-pipeline.postman_collection.json
@@ -1,4 +1,4 @@
-{
+﻿{
 	"info": {
 		"_postman_id": "bc02515e-5673-40fc-b67f-377ee7a2f7cb",
 		"name": "A3S - Pipeline",

--- a/postman/A3S-quickstart.postman_environment.json
+++ b/postman/A3S-quickstart.postman_environment.json
@@ -1,4 +1,4 @@
-{
+﻿{
 	"id": "c9b9c651-2a09-4b57-8d07-84215d101847",
 	"name": "A3S - Quickstart",
 	"values": [


### PR DESCRIPTION
- Enables running Postman integration tests as a job on CircleCI.
- Both the tagged and un-tagged workflows now require postman integration tests to pass.
- Resolves #17 