### PR TITLE
2311 add sentry server to docker compose -> Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,3 +339,6 @@ ASALocalRun/
 
 # Docker storage files, creating from runnign docker images within the project
 *.DS_Store
+
+# Environment file for sentry within the development docker-compose.
+*.env

--- a/development-quickstart/README.md
+++ b/development-quickstart/README.md
@@ -38,3 +38,20 @@ To log into the Open Ldap Admin instance from PHP Admin LDAP, click the login bu
 
 * Login DN: "cn=admin,dc=bigbaobab,dc=org"
 * Password: "admin"
+
+## Sentry
+
+[Sentry](https://sentry.io/welcome/) is currently going to be used for runtime exceptions monitoring. An optional add on docker-compose environment has been developed for adding [sentry](https://sentry.io/welcome/) into the development environment. It is in a separate sentry-docker-compose.yml file, as bringing up the environment is a little more complex than a `docker-compose up`. A script has been developed to ensure this process happens correctly. To bring up the sentry environment:
+
+* Run `./sentry-environment-up.sh`.
+  * This will migrate the sentry database (which happens prior to the actual docker-compose up).
+  * Prompt the user to create a sentry user. This is interactive and will require human input.
+  * Bring up the environment once the prior steps are completed.
+
+To bring down the environment:
+
+* Run `./sentry-environment-down.sh` to bring down the entire environment.
+
+**Note!** The sentry environment requires a persistent docker volume to function. This volume is not destroyed when running the `./sentry-environment-down.sh` script. To truly destroy the environment state, this docker volume will need to be destroyed.
+
+* Run `docker volume rm development-quickstart_sentry-postgres` to destroy the volume and truly reset the state.

--- a/development-quickstart/README.md
+++ b/development-quickstart/README.md
@@ -43,6 +43,7 @@ To log into the Open Ldap Admin instance from PHP Admin LDAP, click the login bu
 
 [Sentry](https://sentry.io/welcome/) is currently going to be used for runtime exceptions monitoring. An optional add on docker-compose environment has been developed for adding [sentry](https://sentry.io/welcome/) into the development environment. It is in a separate sentry-docker-compose.yml file, as bringing up the environment is a little more complex than a `docker-compose up`. A script has been developed to ensure this process happens correctly. To bring up the sentry environment:
 
+* Run `docker-compose run --rm web config generate-secret-key | tail -n 1 | tr -d '\r\n' | awk '{print "SENTRY_SECRET_KEY="$1}' > .env`. This generates the required sentry secret key and places it into a `.env` file.
 * Run `./sentry-environment-up.sh`.
   * This will migrate the sentry database (which happens prior to the actual docker-compose up).
   * Prompt the user to create a sentry user. This is interactive and will require human input.

--- a/development-quickstart/docker-compose.yml
+++ b/development-quickstart/docker-compose.yml
@@ -5,7 +5,27 @@
 # **************************************************
 #
 
-version: '3'
+version: '3.4'
+
+x-defaults: &defaults
+  networks:
+    - a3s-development
+  restart: unless-stopped
+  image: sentry:9.1
+  depends_on:
+    - redis
+    - postgres
+    - memcached
+    - smtp
+  env_file: .env
+  environment:
+    SENTRY_MEMCACHED_HOST: memcached
+    SENTRY_REDIS_HOST: redis
+    SENTRY_POSTGRES_HOST: postgres
+    SENTRY_EMAIL_HOST: smtp
+  # volumes:
+  #   - sentry-data:/var/lib/sentry/files
+
 services:
   a3s-development-postgresql:
     networks:
@@ -74,6 +94,39 @@ services:
     image: "namshi/smtp:latest"
     ports:
       - "25:25"
+
+  memcached:
+    networks:
+      - a3s-development
+    restart: unless-stopped
+    image: memcached:1.5-alpine
+
+  redis:
+    networks:
+      - a3s-development
+    restart: unless-stopped
+    image: redis:3.2-alpine
+
+  postgres:
+    networks:
+      - a3s-development
+    restart: unless-stopped
+    image: postgres:9.5
+    # volumes:
+    #   - sentry-postgres:/var/lib/postgresql/data
+
+  web:
+    <<: *defaults
+    ports:
+      - '9000:9000'
+
+  cron:
+    <<: *defaults
+    command: run cron
+
+  worker:
+    <<: *defaults
+    command: run worker
       
 networks:
   a3s-development:

--- a/development-quickstart/docker-compose.yml
+++ b/development-quickstart/docker-compose.yml
@@ -5,27 +5,7 @@
 # **************************************************
 #
 
-version: '3.4'
-
-x-defaults: &defaults
-  networks:
-    - a3s-development
-  restart: unless-stopped
-  image: sentry:9.1
-  depends_on:
-    - redis
-    - postgres
-    - memcached
-    - smtp
-  env_file: .env
-  environment:
-    SENTRY_MEMCACHED_HOST: memcached
-    SENTRY_REDIS_HOST: redis
-    SENTRY_POSTGRES_HOST: postgres
-    SENTRY_EMAIL_HOST: smtp
-  # volumes:
-  #   - sentry-data:/var/lib/sentry/files
-
+version: '3'
 services:
   a3s-development-postgresql:
     networks:
@@ -94,39 +74,6 @@ services:
     image: "namshi/smtp:latest"
     ports:
       - "25:25"
-
-  memcached:
-    networks:
-      - a3s-development
-    restart: unless-stopped
-    image: memcached:1.5-alpine
-
-  redis:
-    networks:
-      - a3s-development
-    restart: unless-stopped
-    image: redis:3.2-alpine
-
-  postgres:
-    networks:
-      - a3s-development
-    restart: unless-stopped
-    image: postgres:9.5
-    # volumes:
-    #   - sentry-postgres:/var/lib/postgresql/data
-
-  web:
-    <<: *defaults
-    ports:
-      - '9000:9000'
-
-  cron:
-    <<: *defaults
-    command: run cron
-
-  worker:
-    <<: *defaults
-    command: run worker
       
 networks:
   a3s-development:

--- a/development-quickstart/sentry-docker-compose.yml
+++ b/development-quickstart/sentry-docker-compose.yml
@@ -1,0 +1,60 @@
+version: '3.4'
+x-defaults: &defaults
+  networks:
+    - a3s-development
+  restart: unless-stopped
+  image: sentry:9.1
+  depends_on:
+    - redis
+    - postgres
+    - memcached
+    # - smtp
+  env_file: .env
+  environment:
+    SENTRY_MEMCACHED_HOST: memcached
+    SENTRY_REDIS_HOST: redis
+    SENTRY_POSTGRES_HOST: postgres
+    # SENTRY_EMAIL_HOST: smtp
+  # volumes:
+  #   - sentry-data:/var/lib/sentry/files
+
+services:
+  memcached:
+    networks:
+      - a3s-development
+    restart: unless-stopped
+    image: memcached:1.5-alpine
+
+  redis:
+    networks:
+      - a3s-development
+    restart: unless-stopped
+    image: redis:3.2-alpine
+
+  postgres:
+    networks:
+      - a3s-development
+    restart: unless-stopped
+    image: postgres:9.5
+    volumes:
+      - sentry-postgres:/var/lib/postgresql/data
+
+  web:
+    <<: *defaults
+    ports:
+      - '9000:9000'
+
+  cron:
+    <<: *defaults
+    command: run cron
+
+  worker:
+    <<: *defaults
+    command: run worker
+
+volumes:
+   sentry-postgres:
+     # external: true
+      
+networks:
+  a3s-development:

--- a/development-quickstart/sentry-docker-compose.yml
+++ b/development-quickstart/sentry-docker-compose.yml
@@ -1,3 +1,10 @@
+#
+# *************************************************
+# Copyright (c) 2019, Grindrod Bank Limited
+# License MIT: https://opensource.org/licenses/MIT
+# **************************************************
+#
+
 version: '3.4'
 x-defaults: &defaults
   networks:

--- a/development-quickstart/sentry-environment-down.sh
+++ b/development-quickstart/sentry-environment-down.sh
@@ -1,2 +1,9 @@
+#
+# *************************************************
+# Copyright (c) 2019, Grindrod Bank Limited
+# License MIT: https://opensource.org/licenses/MIT
+# **************************************************
+#
+
 echo "Destroying the Development Environment"
 docker-compose -f sentry-docker-compose.yml down

--- a/development-quickstart/sentry-environment-down.sh
+++ b/development-quickstart/sentry-environment-down.sh
@@ -1,0 +1,2 @@
+echo "Destroying the Development Environment"
+docker-compose -f sentry-docker-compose.yml down

--- a/development-quickstart/sentry-environment-up.sh
+++ b/development-quickstart/sentry-environment-up.sh
@@ -15,3 +15,5 @@ docker-compose -f sentry-docker-compose.yml run --rm web createuser
 
 echo "Bringing up the Environment"
 docker-compose -f sentry-docker-compose.yml up
+
+echo "Sentry is now listening on `localhost:9000`"

--- a/development-quickstart/sentry-environment-up.sh
+++ b/development-quickstart/sentry-environment-up.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Migrating the Sentry Database"
+docker-compose -f sentry-docker-compose.yml run --rm web upgrade --noinput
+
+echo "Creating Sentry User"
+docker-compose -f sentry-docker-compose.yml run --rm web createuser
+
+echo "Bringing up the Environment"
+docker-compose -f sentry-docker-compose.yml up

--- a/development-quickstart/sentry-environment-up.sh
+++ b/development-quickstart/sentry-environment-up.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+# *************************************************
+# Copyright (c) 2019, Grindrod Bank Limited
+# License MIT: https://opensource.org/licenses/MIT
+# **************************************************
+#
+
 
 echo "Migrating the Sentry Database"
 docker-compose -f sentry-docker-compose.yml run --rm web upgrade --noinput


### PR DESCRIPTION
- Adds an optional docker-compose environment and supporting scripts for adding a sentry environment to A3S.
- Resolves #20 