### PR TITLE
Add sentry client -> Master

### DIFF
--- a/src/za.co.grindrodbank.a3s/Extensions/ExceptionMiddlewareExtensions.cs
+++ b/src/za.co.grindrodbank.a3s/Extensions/ExceptionMiddlewareExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using NLog;
 using za.co.grindrodbank.a3s.A3SApiResources;
+using Microsoft.Extensions.Configuration;
+using Sentry;
 
 namespace GlobalErrorHandling.Extensions
 {
@@ -19,7 +21,7 @@ namespace GlobalErrorHandling.Extensions
     {
         private static readonly ILogger logger = LogManager.GetCurrentClassLogger();
 
-        public static void ConfigureExceptionHandler(this IApplicationBuilder app)
+        public static void ConfigureExceptionHandler(this IApplicationBuilder app, IConfiguration configuration)
         {
             app.UseExceptionHandler(appError =>
             {
@@ -39,11 +41,12 @@ namespace GlobalErrorHandling.Extensions
                         return;
                     }
 
+                    writeException(contextFeature.Error, configuration);
+
                     // Check for a YAML structure error
                     if (contextFeature.Error is YamlDotNet.Core.SyntaxErrorException || contextFeature.Error is YamlDotNet.Core.YamlException)
                     {
                         context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                        logger.Error($"Something went wrong: {contextFeature.Error}");
 
                         await context.Response.WriteAsync(new ErrorResponse()
                         {
@@ -57,7 +60,6 @@ namespace GlobalErrorHandling.Extensions
                     if (contextFeature.Error is ItemNotFoundException)
                     {
                         context.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                        logger.Error($"Item not found exception: {contextFeature.Error}");
 
                         await context.Response.WriteAsync(new ErrorResponse()
                         {
@@ -71,7 +73,6 @@ namespace GlobalErrorHandling.Extensions
                     if (contextFeature.Error is ItemNotProcessableException)
                     {
                         context.Response.StatusCode = (int)HttpStatusCode.UnprocessableEntity;
-                        logger.Error($"Item not processable exception: {contextFeature.Error}");
 
                         await context.Response.WriteAsync(new ErrorResponse()
                         {
@@ -83,7 +84,6 @@ namespace GlobalErrorHandling.Extensions
 
                     // Default 500 Catch All
                     context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
-                    logger.Error($"Something went wrong: {contextFeature.Error}");
 
                     await context.Response.WriteAsync(new ErrorResponse()
                     {
@@ -91,6 +91,17 @@ namespace GlobalErrorHandling.Extensions
                     }.ToJson());
                 });
             });
+        }
+
+        public static void writeException(Exception exception, IConfiguration configuration)
+        {
+            var sentryEnabled = bool.Parse(configuration["Sentry:Enabled"]);
+            logger.Error(exception);
+
+            if (sentryEnabled)
+            {
+                SentrySdk.CaptureException(exception);
+            }
         }
     }
 }

--- a/src/za.co.grindrodbank.a3s/Extensions/ExceptionMiddlewareExtensions.cs
+++ b/src/za.co.grindrodbank.a3s/Extensions/ExceptionMiddlewareExtensions.cs
@@ -41,7 +41,7 @@ namespace GlobalErrorHandling.Extensions
                         return;
                     }
 
-                    writeException(contextFeature.Error, configuration);
+                    WriteException(contextFeature.Error, configuration);
 
                     // Check for a YAML structure error
                     if (contextFeature.Error is YamlDotNet.Core.SyntaxErrorException || contextFeature.Error is YamlDotNet.Core.YamlException)
@@ -93,7 +93,7 @@ namespace GlobalErrorHandling.Extensions
             });
         }
 
-        public static void writeException(Exception exception, IConfiguration configuration)
+        public static void WriteException(Exception exception, IConfiguration configuration)
         {
             var sentryEnabled = bool.Parse(configuration["Sentry:Enabled"]);
             logger.Error(exception);

--- a/src/za.co.grindrodbank.a3s/Program.cs
+++ b/src/za.co.grindrodbank.a3s/Program.cs
@@ -4,10 +4,13 @@
  * License MIT: https://opensource.org/licenses/MIT
  * **************************************************
  */
-﻿using Microsoft.AspNetCore;
+using System;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using NLog;
 using NLog.Web;
+using Sentry;
 
 namespace za.co.grindrodbank.a3s
 {
@@ -15,7 +18,36 @@ namespace za.co.grindrodbank.a3s
     {
         public static void Main(string[] args)
         {
+            // The application configuration needs to be manually created and bound here. DI does not work yet.
+            var configBuilder = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", optional: false);
+            
+            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
 
+            if (environment != null)
+            {
+                configBuilder.AddJsonFile($"appsettings.{environment}.json", optional: true);
+            }
+            
+            var config = configBuilder.Build();
+            var sentryEnabled = bool.Parse(config["Sentry:Enabled"]);
+
+            if (sentryEnabled)
+            {
+                using (SentrySdk.Init(config["Sentry:Dsn"]))
+                {
+                    StartApp(args);
+                }
+            }
+            else
+            {
+                StartApp(args);
+            }
+            
+        }
+
+        public static void StartApp(string[] args)
+        {
             NLogBuilder.ConfigureNLog("nlog.config");
 
             try

--- a/src/za.co.grindrodbank.a3s/Startup.cs
+++ b/src/za.co.grindrodbank.a3s/Startup.cs
@@ -185,7 +185,7 @@ namespace za.co.grindrodbank.a3s
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            app.ConfigureExceptionHandler();
+            app.ConfigureExceptionHandler(Configuration);
 
             if (!env.IsDevelopment())
             {

--- a/src/za.co.grindrodbank.a3s/appsettings.Development.json
+++ b/src/za.co.grindrodbank.a3s/appsettings.Development.json
@@ -13,4 +13,8 @@
     "Issuer": "http://localhost:5000",
     "Audience": "a3s"
   },
+  "Sentry": {
+    "Enabled": true,
+    "Dsn": "http://c0798c13b05c4d5c96401f02eb955ee7@localhost:9000/2"
+  }
 }

--- a/src/za.co.grindrodbank.a3s/appsettings.json
+++ b/src/za.co.grindrodbank.a3s/appsettings.json
@@ -13,6 +13,9 @@
     "Audience": "a3s"
   },
   "EncryptionKeys": {
-      "LdapAdminKey": "this.secret.key.736"
+    "LdapAdminKey": "this.secret.key.736"
+  },
+  "Sentry": {
+    "Enabled": false
   }
 }

--- a/src/za.co.grindrodbank.a3s/za.co.grindrodbank.a3s.csproj
+++ b/src/za.co.grindrodbank.a3s/za.co.grindrodbank.a3s.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="IdentityServer4.EntityFramework" Version="2.5.3" />
     <PackageReference Include="IdentityServer4" Version="2.5.3" />
+    <PackageReference Include="Sentry" Version="1.2.0" />
     <PackageReference Include="Steeltoe.Management.EndpointCore" Version="2.3.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />


### PR DESCRIPTION
- Adds Sentry reporting client, and all it's dependencies to A3S.
- Adds configurations and updates to several code portion to make Sentry reporting configurable. You can turn off notifications to the sentry server, and even booting the application with the sentry listener from the application configuration.
- Updates the Global Exception handler to now publish all caught exceptions to the Sentry server if sentry publishing is enabled within the configuration. By default, only un-handled exceptions get reported to Sentry, so it was necessary to augment the Global exceptions handler, which catches all exceptions bubble up from the app.
- Resolves #23 