### PR TITLE
62 prevent null cors origin on client declaration -> Master

### DIFF
--- a/doc/a3s-openapi.yaml
+++ b/doc/a3s-openapi.yaml
@@ -1,4 +1,4 @@
-﻿openapi: 3.0.0
+openapi: 3.0.0
 info:
   description: >-
     API Definition for the A3S. This service allows authentication, authorisation and accounting.
@@ -3032,8 +3032,6 @@ components:
         - allowedScopes
         - allowedOfflineAccess
         - redirectUris
-        - allowedCorsOrigins
-        - postLogoutRedirectUris
       properties:
         clientId:
           type: string

--- a/src/za.co.grindrodbank.a3s/A3SApiResources/Oauth2ClientSubmit.cs
+++ b/src/za.co.grindrodbank.a3s/A3SApiResources/Oauth2ClientSubmit.cs
@@ -68,7 +68,6 @@ namespace za.co.grindrodbank.a3s.A3SApiResources
         /// Sets the allowed CORS origins for JavaScript clients.
         /// </summary>
         /// <value>Sets the allowed CORS origins for JavaScript clients.</value>
-        [Required]
         [DataMember(Name="allowedCorsOrigins", EmitDefaultValue=false)]
         public List<string> AllowedCorsOrigins { get; set; }
 
@@ -76,7 +75,6 @@ namespace za.co.grindrodbank.a3s.A3SApiResources
         /// Specifies the allowed URIs to redirect to after logout.
         /// </summary>
         /// <value>Specifies the allowed URIs to redirect to after logout.</value>
-        [Required]
         [DataMember(Name="postLogoutRedirectUris", EmitDefaultValue=false)]
         public List<string> PostLogoutRedirectUris { get; set; }
 

--- a/src/za.co.grindrodbank.a3s/Exceptions/InvalidFormatException.cs
+++ b/src/za.co.grindrodbank.a3s/Exceptions/InvalidFormatException.cs
@@ -1,0 +1,34 @@
+/**
+ * *************************************************
+ * Copyright (c) 2019, Grindrod Bank Limited
+ * License MIT: https://opensource.org/licenses/MIT
+ * **************************************************
+ */
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace za.co.grindrodbank.a3s.Exceptions
+{
+    [Serializable]
+    public sealed class InvalidFormatException : Exception
+    {
+        private const string defaultMessage = "Item is not correctly formatted.";
+
+        public InvalidFormatException() : base(defaultMessage)
+        {
+        }
+
+        public InvalidFormatException(string message) : base(!string.IsNullOrEmpty(message) ? message : defaultMessage)
+        {
+        }
+
+        public InvalidFormatException(string message, Exception innerException) : base(!string.IsNullOrEmpty(message) ? message : defaultMessage, innerException)
+        {
+        }
+
+        private InvalidFormatException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+        {
+        }
+    }
+}

--- a/src/za.co.grindrodbank.a3s/Exceptions/ItemNotFoundException.cs
+++ b/src/za.co.grindrodbank.a3s/Exceptions/ItemNotFoundException.cs
@@ -6,7 +6,6 @@
  */
 ﻿using System;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace za.co.grindrodbank.a3s.Exceptions
 {

--- a/src/za.co.grindrodbank.a3s/Exceptions/ItemNotProcessableException.cs
+++ b/src/za.co.grindrodbank.a3s/Exceptions/ItemNotProcessableException.cs
@@ -6,7 +6,6 @@
  */
 ﻿using System;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace za.co.grindrodbank.a3s.Exceptions
 {

--- a/src/za.co.grindrodbank.a3s/Exceptions/OperationFailedException.cs
+++ b/src/za.co.grindrodbank.a3s/Exceptions/OperationFailedException.cs
@@ -6,7 +6,6 @@
  */
 ﻿using System;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace za.co.grindrodbank.a3s.Exceptions
 {

--- a/src/za.co.grindrodbank.a3s/Extensions/ExceptionMiddlewareExtensions.cs
+++ b/src/za.co.grindrodbank.a3s/Extensions/ExceptionMiddlewareExtensions.cs
@@ -80,6 +80,19 @@ namespace GlobalErrorHandling.Extensions
                         return;
                     }
 
+                    // Check for a Invalid Format Exception error
+                    if (contextFeature.Error is InvalidFormatException)
+                    {
+                        context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+
+                        await context.Response.WriteAsync(new ErrorResponse()
+                        {
+                            Message = contextFeature.Error.Message
+                        }.ToJson());
+
+                        return;
+                    }
+
                     // Default 500 Catch All
                     context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 

--- a/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
+++ b/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
@@ -118,10 +118,10 @@ namespace za.co.grindrodbank.a3s.Services
                 });
             }
 
+            client.PostLogoutRedirectUris = new List<ClientPostLogoutRedirectUri>();
+
             if (oauth2ClientSubmit.PostLogoutRedirectUris != null && oauth2ClientSubmit.PostLogoutRedirectUris.Any())
             {
-                client.PostLogoutRedirectUris = new List<ClientPostLogoutRedirectUri>();
-
                 foreach (var postLogoutRedirectUri in oauth2ClientSubmit.PostLogoutRedirectUris)
                 {
                     client.PostLogoutRedirectUris.Add(new ClientPostLogoutRedirectUri
@@ -132,10 +132,10 @@ namespace za.co.grindrodbank.a3s.Services
                 }
             }
 
+            client.AllowedCorsOrigins = new List<ClientCorsOrigin>();
+
             if (oauth2ClientSubmit.AllowedCorsOrigins != null && oauth2ClientSubmit.AllowedCorsOrigins.Any())
             {
-                client.AllowedCorsOrigins = new List<ClientCorsOrigin>();
-
                 foreach (var corsOrigin in oauth2ClientSubmit.AllowedCorsOrigins)
                 {
                     if (string.IsNullOrWhiteSpace(corsOrigin))

--- a/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
+++ b/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
@@ -118,30 +118,37 @@ namespace za.co.grindrodbank.a3s.Services
                 });
             }
 
-            client.PostLogoutRedirectUris = new List<ClientPostLogoutRedirectUri>();
-
-            foreach(var postLogoutRedirectUri in oauth2ClientSubmit.PostLogoutRedirectUris)
+            if (oauth2ClientSubmit.PostLogoutRedirectUris != null && oauth2ClientSubmit.PostLogoutRedirectUris.Any())
             {
-                client.PostLogoutRedirectUris.Add(new ClientPostLogoutRedirectUri
+                client.PostLogoutRedirectUris = new List<ClientPostLogoutRedirectUri>();
+
+                foreach (var postLogoutRedirectUri in oauth2ClientSubmit.PostLogoutRedirectUris)
                 {
-                    Client = client,
-                    PostLogoutRedirectUri = postLogoutRedirectUri
-                });
+                    client.PostLogoutRedirectUris.Add(new ClientPostLogoutRedirectUri
+                    {
+                        Client = client,
+                        PostLogoutRedirectUri = postLogoutRedirectUri
+                    });
+                }
             }
 
-            client.AllowedCorsOrigins = new List<ClientCorsOrigin>();
-
-            foreach(var corsOrigin in oauth2ClientSubmit.AllowedCorsOrigins)
+            if (oauth2ClientSubmit.AllowedCorsOrigins != null && oauth2ClientSubmit.AllowedCorsOrigins.Any())
             {
-                if (string.IsNullOrWhiteSpace(corsOrigin))
-                {
-                    throw new InvalidFormatException($"Empty or null 'allowedCorsOrigin' declared for client: '{oauth2ClientSubmit.ClientId}'");
-                }
+                client.AllowedCorsOrigins = new List<ClientCorsOrigin>();
 
-                client.AllowedCorsOrigins.Add(new ClientCorsOrigin {
-                    Client = client,
-                    Origin = corsOrigin
-                });
+                foreach (var corsOrigin in oauth2ClientSubmit.AllowedCorsOrigins)
+                {
+                    if (string.IsNullOrWhiteSpace(corsOrigin))
+                    {
+                        throw new InvalidFormatException($"Empty or null 'allowedCorsOrigin' declared for client: '{oauth2ClientSubmit.ClientId}'");
+                    }
+
+                    client.AllowedCorsOrigins.Add(new ClientCorsOrigin
+                    {
+                        Client = client,
+                        Origin = corsOrigin
+                    });
+                }
             }
 
             if (newClient)

--- a/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
+++ b/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
@@ -13,6 +13,7 @@ using IdentityServer4.EntityFramework.Entities;
 using IdentityServer4.Models;
 using NLog;
 using za.co.grindrodbank.a3s.A3SApiResources;
+using za.co.grindrodbank.a3s.Exceptions;
 
 namespace za.co.grindrodbank.a3s.Services
 {
@@ -132,6 +133,11 @@ namespace za.co.grindrodbank.a3s.Services
 
             foreach(var corsOrigin in oauth2ClientSubmit.AllowedCorsOrigins)
             {
+                if (string.IsNullOrEmpty(corsOrigin))
+                {
+                    throw new InvalidFormatException($"Empty or null 'allowedCorsOrigin' declared for client: '{oauth2ClientSubmit.ClientId}'");
+                }
+
                 client.AllowedCorsOrigins.Add(new ClientCorsOrigin {
                     Client = client,
                     Origin = corsOrigin

--- a/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
+++ b/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
@@ -133,7 +133,7 @@ namespace za.co.grindrodbank.a3s.Services
 
             foreach(var corsOrigin in oauth2ClientSubmit.AllowedCorsOrigins)
             {
-                if (string.IsNullOrEmpty(corsOrigin))
+                if (string.IsNullOrWhiteSpace(corsOrigin))
                 {
                     throw new InvalidFormatException($"Empty or null 'allowedCorsOrigin' declared for client: '{oauth2ClientSubmit.ClientId}'");
                 }

--- a/src/za.co.grindrodbank.a3s/Startup.cs
+++ b/src/za.co.grindrodbank.a3s/Startup.cs
@@ -243,22 +243,32 @@ namespace za.co.grindrodbank.a3s
             {
                 var context = serviceScope.ServiceProvider.GetRequiredService<A3SContext>();
 
+                var writePermission = context.Permission.Where(p => p.Name == "a3s.securityContracts.update").FirstOrDefault();
+
+                if(writePermission == null)
+                {
+                    writePermission = new PermissionModel
+                    {
+                        Name = "a3s.securityContracts.update",
+                        Description = "Enables idempotently applying (creating or updating) a security contract definition. This includes creation or updating of permissions, functions, applications and the relationships between them.",
+                        ChangedBy = Guid.Empty
+                    };
+                }
+
+                var readPermission = context.Permission.Where(p => p.Name == "a3s.securityContracts.read").FirstOrDefault();
+
+                if(readPermission == null)
+                {
+                    readPermission = new PermissionModel
+                    {
+                        Name = "a3s.securityContracts.read",
+                        Description = "Enables fetching of a security contract definition.",
+                        ChangedBy = Guid.Empty
+                    };
+                }
+                
                 // Ensure that the A3S application is createdd.
                 var application = context.Application.Where(a => a.Name == "a3s").FirstOrDefault();
-
-                var writePermission = new PermissionModel
-                {
-                    Name = "a3s.securityContracts.update",
-                    Description = "Enables idempotently applying (creating or updating) a security contract definition. This includes creation or updating of permissions, functions, applications and the relationships between them.",
-                    ChangedBy = Guid.Empty
-                };
-
-                var readPermission = new PermissionModel
-                {
-                    Name = "a3s.securityContracts.read",
-                    Description = "Enables fetching of a security contract definition.",
-                    ChangedBy = Guid.Empty
-                };
 
                 if (application == null)
                 {

--- a/src/za.co.grindrodbank.a3s/wwwroot/openapi-original.json
+++ b/src/za.co.grindrodbank.a3s/wwwroot/openapi-original.json
@@ -4756,7 +4756,7 @@
             "type" : "integer"
           }
         },
-        "required" : [ "allowedCorsOrigins", "allowedGrantTypes", "allowedOfflineAccess", "allowedScopes", "clientId", "name", "postLogoutRedirectUris", "redirectUris" ],
+        "required" : [ "allowedGrantTypes", "allowedOfflineAccess", "allowedScopes", "clientId", "name", "redirectUris" ],
         "type" : "object"
       },
       "Oauth2Client" : {

--- a/tests/postman-integration-tests/A3S-integration.postman_collection.json
+++ b/tests/postman-integration-tests/A3S-integration.postman_collection.json
@@ -1,6 +1,6 @@
 ﻿{
 	"info": {
-		"_postman_id": "57d11e69-7faf-481b-a2e1-b86127921be0",
+		"_postman_id": "355fca5a-49cd-4711-a8b8-27065753311a",
 		"name": "A3S - Integration",
 		"description": "A Postman collection desgined to be executed remotely using Newman within the CI/CD context.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -7269,6 +7269,184 @@
 									"    pm.expect(jsonData.clients[2].redirectUris[0]).to.eql('https://www.getpostman.com/oauth2/callback');",
 									"    pm.expect(jsonData.clients[2].postLogoutRedirectUris[0]).to.eql('https://www.getpostman.com');",
 									"    pm.expect(jsonData.clients[2].allowedCorsOrigins[0]).to.eql('https://www.getpostman.com');",
+									"    pm.expect(jsonData.clients[2].allowedScopes[0]).to.eql('a3s');",
+									"    pm.expect(jsonData.clients[2].allowedScopes[1]).to.eql('dokuti');",
+									"    pm.expect(jsonData.clients[2].allowedScopes[2]).to.eql('openid');",
+									"    pm.expect(jsonData.clients[2].allowedScopes[3]).to.eql('profile');",
+									"    pm.expect(jsonData.clients[2].hashedClientSecrets[0]).to.eql('K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols=');",
+									"    pm.expect(jsonData.clients[2].allowedOfflineAccess).to.eql(true);",
+									"});",
+									"",
+									"pm.test(\"Check that returned Security Contract has correctly structured application level. Checking first application.\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.applications[0]).to.have.property('fullname');",
+									"    pm.expect(jsonData.applications[0]).to.have.property('applicationFunctions');",
+									"    pm.expect(jsonData.applications[0]).to.have.property('dataPolicies');",
+									"});",
+									"",
+									"pm.test(\"Check that returned Security Contract has correctly structured default configurations level. Checking first default configuration.\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.defaultConfigurations[0]).to.have.property('name');",
+									"    pm.expect(jsonData.defaultConfigurations[0]).to.have.property('applications');",
+									"    pm.expect(jsonData.defaultConfigurations[0]).to.have.property('roles');",
+									"    pm.expect(jsonData.defaultConfigurations[0]).to.have.property('users');",
+									"    pm.expect(jsonData.defaultConfigurations[0]).to.have.property('teams');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "accessToken",
+									"value": "{{session_access_token}}",
+									"type": "string"
+								},
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/x-yaml"
+							},
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{a3s-host}}/securityContracts",
+							"host": [
+								"{{a3s-host}}"
+							],
+							"path": [
+								"securityContracts"
+							]
+						},
+						"description": "Retrieves the entire security contract. Note: YAML is the preferred returned format, but these requests are asking for JSON to be returned so that Postman content analysis is easier. Checks the client that was created in the previous partial security contract upload is correct."
+					},
+					"response": []
+				},
+				{
+					"name": "PutSecurityContractDefinition - Empty Non Required Client Fields",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "53f866e8-5434-4e46-8610-dbe1c3781067",
+								"exec": [
+									"pm.test(\"Response is OK - 204 no content\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "accessToken",
+									"value": "{{session_access_token}}",
+									"type": "string"
+								},
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/x-yaml"
+							},
+							{
+								"key": "",
+								"type": "text",
+								"value": "",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "clients:\n  - clientId: test-security-contract-api\n    name: \"Test security contract client\"\n    allowedGrantTypes:\n      - authorization_code\n      - password\n    redirectUris:\n      - \"https://www.getpostman.com/oauth2/callback\"\n    allowedScopes:\n      - \"openid\"\n      - \"profile\"\n      - \"dokuti\"\n      - \"a3s\"\n    clientSecrets:\n      - \"secret\"\n    allowedOfflineAccess: true\n"
+						},
+						"url": {
+							"raw": "{{a3s-host}}/securityContracts",
+							"host": [
+								"{{a3s-host}}"
+							],
+							"path": [
+								"securityContracts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetSecurityContractDefinition - TestEmpty Non Required Client Fields - Expect Empty Values on Returned Client",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "77f72596-003e-4637-8428-c3bcd38a88b6",
+								"exec": [
+									"pm.test(\"Response is OK\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Check that returned Security Contract is correctly structured at the top level.\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property('clients');",
+									"    pm.expect(jsonData).to.have.property('applications');",
+									"    pm.expect(jsonData).to.have.property('defaultConfigurations');",
+									"});",
+									"",
+									"pm.test(\"Check that returned Security Contract has correctly structured client level. Checking first client.\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.clients[0]).to.have.property('clientId');",
+									"    pm.expect(jsonData.clients[0]).to.have.property('name');",
+									"    pm.expect(jsonData.clients[0]).to.have.property('allowedGrantTypes');",
+									"    pm.expect(jsonData.clients[0]).to.have.property('redirectUris');",
+									"    pm.expect(jsonData.clients[0]).to.have.property('allowedCorsOrigins');",
+									"    pm.expect(jsonData.clients[0]).to.have.property('postLogoutRedirectUris');",
+									"    pm.expect(jsonData.clients[0]).to.have.property('allowedScopes');",
+									"    pm.expect(jsonData.clients[0]).to.have.property('hashedClientSecrets');",
+									"    pm.expect(jsonData.clients[0]).to.have.property('allowedOfflineAccess');",
+									"});",
+									"",
+									"pm.test(\"Check that the amount of clients has increased to 3.\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.clients.length).to.equal(3);",
+									"});",
+									"",
+									"pm.test(\"Check that the newly created client was correctly created.\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.clients[2].clientId).to.eql('test-security-contract-api');",
+									"    pm.expect(jsonData.clients[2].name).to.eql('Test security contract client');",
+									"    pm.expect(jsonData.clients[2].allowedGrantTypes[0]).to.eql('authorization_code');",
+									"    pm.expect(jsonData.clients[2].allowedGrantTypes[1]).to.eql('password');",
+									"    pm.expect(jsonData.clients[2].redirectUris[0]).to.eql('https://www.getpostman.com/oauth2/callback');",
+									"    pm.expect(jsonData.clients[2].postLogoutRedirectUris.length).to.eql(0);",
+									"    pm.expect(jsonData.clients[2].allowedCorsOrigins.length).to.eql(0);",
 									"    pm.expect(jsonData.clients[2].allowedScopes[0]).to.eql('a3s');",
 									"    pm.expect(jsonData.clients[2].allowedScopes[1]).to.eql('dokuti');",
 									"    pm.expect(jsonData.clients[2].allowedScopes[2]).to.eql('openid');",

--- a/tests/postman-integration-tests/A3S-integration.postman_collection.json
+++ b/tests/postman-integration-tests/A3S-integration.postman_collection.json
@@ -1,6 +1,6 @@
 ﻿{
 	"info": {
-		"_postman_id": "dcec171a-627e-4a45-a939-0f9bbb3dfbe8",
+		"_postman_id": "57d11e69-7faf-481b-a2e1-b86127921be0",
 		"name": "A3S - Integration",
 		"description": "A Postman collection desgined to be executed remotely using Newman within the CI/CD context.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -7336,6 +7336,68 @@
 							]
 						},
 						"description": "Retrieves the entire security contract. Note: YAML is the preferred returned format, but these requests are asking for JSON to be returned so that Postman content analysis is easier. Checks the client that was created in the previous partial security contract upload is correct."
+					},
+					"response": []
+				},
+				{
+					"name": "PutSecurityContractDefinition - New Client - Empty CORS Origins - Expect 400",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "53f866e8-5434-4e46-8610-dbe1c3781067",
+								"exec": [
+									"pm.test(\"Response is 400 - Bad Request\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "accessToken",
+									"value": "{{session_access_token}}",
+									"type": "string"
+								},
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/x-yaml"
+							},
+							{
+								"key": "",
+								"type": "text",
+								"value": "",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "clients:\n  - clientId: test-security-contract-api\n    name: \"Test security contract client\"\n    allowedGrantTypes:\n      - authorization_code\n      - password\n    redirectUris:\n      - \"https://www.getpostman.com/oauth2/callback\"\n    postLogoutRedirectUris:\n      - \"https://www.getpostman.com\"\n    allowedCorsOrigins:\n      - \"\"\n    allowedScopes:\n      - \"openid\"\n      - \"profile\"\n      - \"dokuti\"\n      - \"a3s\"\n    clientSecrets:\n      - \"secret\"\n    allowedOfflineAccess: true\n"
+						},
+						"url": {
+							"raw": "{{a3s-host}}/securityContracts",
+							"host": [
+								"{{a3s-host}}"
+							],
+							"path": [
+								"securityContracts"
+							]
+						}
 					},
 					"response": []
 				},

--- a/tests/za.co.grindrodbank.a3s.tests/Services/SecurityContractClientService_Tests.cs
+++ b/tests/za.co.grindrodbank.a3s.tests/Services/SecurityContractClientService_Tests.cs
@@ -211,5 +211,57 @@ namespace za.co.grindrodbank.a3s.tests.Services
                 Assert.True(e is InvalidFormatException);
             }
         }
+
+        [Fact]
+        public async Task ApplyClientDefninition_NoAllowedCorsOriginDefined_ReturnsClientWithEmptyAllowedCorsOrigins()
+        {
+            var clientRespository = Substitute.For<IIdentityClientRepository>();
+            // The service will look for an existing client by it's ID, return null to trigger the client creation flow.
+            clientRespository.GetByClientIdAsync(Arg.Any<string>()).Returns(mockedClientEntity);
+            clientRespository.UpdateAsync(Arg.Any<Client>()).Returns(mockedClientEntity);
+
+            var oauthClientSubmitMock = oauth2ClientSubmit;
+            // Set the allowed CORS orgin array member to an empty string field. This should throw a v
+            oauthClientSubmitMock.AllowedCorsOrigins = null;
+
+            var clientService = new SecurityContractClientService(clientRespository, mapper);
+            var updateClientResource = await clientService.ApplyClientDefinitionAsync(oauthClientSubmitMock);
+
+           
+            Assert.True(updateClientResource.Name == oauth2ClientSubmit.Name, $"Retrieved name: {updateClientResource.Name} not the same as the expected name: {oauth2ClientSubmit.Name}");
+            Assert.True(updateClientResource.ClientId == oauth2ClientSubmit.ClientId, $"Retrieved clientId: {updateClientResource.ClientId} not the same as the expected name: {oauth2ClientSubmit.ClientId}");
+            Assert.True(updateClientResource.AllowedOfflineAccess == true, $"Retrieved allowedOfflineAccess: {updateClientResource.AllowedOfflineAccess} not the expeced value: true");
+            Assert.True(updateClientResource.AllowedGrantTypes.First() == oauth2ClientSubmit.AllowedGrantTypes.First(), $"Retrieved allowedGrantTypes first element: {updateClientResource.AllowedGrantTypes.First()} not the expected value: {oauth2ClientSubmit.AllowedGrantTypes.First()}");
+            Assert.True(!updateClientResource.AllowedCorsOrigins.Any(), $"Retrieved allowedCorsOrigins is expected to be empty, but it is not.");
+            Assert.True(updateClientResource.PostLogoutRedirectUris.First() == oauth2ClientSubmit.PostLogoutRedirectUris.First(), $"Retrieved PostLogoutRedirectUris first element: {updateClientResource.PostLogoutRedirectUris.First()} not the expected value: {oauth2ClientSubmit.PostLogoutRedirectUris.First()}");
+            Assert.True(updateClientResource.AllowedScopes.First() == oauth2ClientSubmit.AllowedScopes.First(), $"Retrieved AllowedScopes first element: {updateClientResource.AllowedScopes.First()} not the expected value: {oauth2ClientSubmit.AllowedScopes.First()}");
+            Assert.True(updateClientResource.RedirectUris.First() == oauth2ClientSubmit.RedirectUris.First(), $"Retrieved RedirectUris first element: {updateClientResource.RedirectUris.First()} not the expected value: {oauth2ClientSubmit.RedirectUris.First()}");
+        }
+
+        [Fact]
+        public async Task ApplyClientDefninition_NoPostLogoutRedirectUrisDefined_ReturnsClientWithEmptyPostLogoutRredirectUris()
+        {
+            var clientRespository = Substitute.For<IIdentityClientRepository>();
+            // The service will look for an existing client by it's ID, return null to trigger the client creation flow.
+            clientRespository.GetByClientIdAsync(Arg.Any<string>()).Returns(mockedClientEntity);
+            clientRespository.UpdateAsync(Arg.Any<Client>()).Returns(mockedClientEntity);
+
+            var oauthClientSubmitMock = oauth2ClientSubmit;
+            // Set the allowed CORS orgin array member to an empty string field. This should throw a v
+            oauthClientSubmitMock.PostLogoutRedirectUris = null;
+
+            var clientService = new SecurityContractClientService(clientRespository, mapper);
+            var updateClientResource = await clientService.ApplyClientDefinitionAsync(oauthClientSubmitMock);
+
+
+            Assert.True(updateClientResource.Name == oauth2ClientSubmit.Name, $"Retrieved name: {updateClientResource.Name} not the same as the expected name: {oauth2ClientSubmit.Name}");
+            Assert.True(updateClientResource.ClientId == oauth2ClientSubmit.ClientId, $"Retrieved clientId: {updateClientResource.ClientId} not the same as the expected name: {oauth2ClientSubmit.ClientId}");
+            Assert.True(updateClientResource.AllowedOfflineAccess == true, $"Retrieved allowedOfflineAccess: {updateClientResource.AllowedOfflineAccess} not the expeced value: true");
+            Assert.True(updateClientResource.AllowedGrantTypes.First() == oauth2ClientSubmit.AllowedGrantTypes.First(), $"Retrieved allowedGrantTypes first element: {updateClientResource.AllowedGrantTypes.First()} not the expected value: {oauth2ClientSubmit.AllowedGrantTypes.First()}");
+            Assert.True(updateClientResource.AllowedCorsOrigins.First() == oauth2ClientSubmit.AllowedCorsOrigins.First(), $"Retrieved allowedCorsOrigins first element: {updateClientResource.AllowedCorsOrigins.First()} not the expected value: {oauth2ClientSubmit.AllowedCorsOrigins.First()}");
+            Assert.True(!updateClientResource.PostLogoutRedirectUris.Any(), $"Retrieved PostLogoutRedirectUris is expected to be empty, but it is not.");
+            Assert.True(updateClientResource.AllowedScopes.First() == oauth2ClientSubmit.AllowedScopes.First(), $"Retrieved AllowedScopes first element: {updateClientResource.AllowedScopes.First()} not the expected value: {oauth2ClientSubmit.AllowedScopes.First()}");
+            Assert.True(updateClientResource.RedirectUris.First() == oauth2ClientSubmit.RedirectUris.First(), $"Retrieved RedirectUris first element: {updateClientResource.RedirectUris.First()} not the expected value: {oauth2ClientSubmit.RedirectUris.First()}");
+        }
     }
 }


### PR DESCRIPTION
- Updates the validation rules for allowed CORS origins within the security contract.
- Fixes a small bug within the initial A3S bootstrapping.
- Adds a new invalid format exception.
- Adds new integration tests for verifying newly added CORS validation.
- Resolves #62 