### PR TITLE
Push security lib to nuget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,16 @@ jobs:
           root: ~/build
           paths:
             - tests/*
-          
+  build-dotnet-libs:
+    docker:
+      - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
+    working_directory: ~/build
+    steps:
+      - checkout
+      - run: cd shared-libraries/resource-server-policy-enforcement/cs
+      - run: pwd; dotnet restore
+      - run: dotnet build
+      - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       
   static-analysis:
     docker:
       - image: newtmitch/sonar-scanner:alpine
@@ -231,6 +240,7 @@ workflows:
       - vulnerability-test
       - license-headers
       - postman-integration-tests
+      - build-dotnet-libs
       - fossa-scan:
           filters:    
             branches:    
@@ -248,6 +258,7 @@ workflows:
       - fossa-scan: *only-tags
       - postman-integration-tests: *only-tags
       - generate-axios-client: *only-tags
+      - build-dotnet-libs: *only-tags
       - a3s-docker-build-push:
           requires:
           - unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - checkout:
           path: ~/build
-      - run: cp ~/build/LICENSE ./a3s-policy-enforcement
+      - run: cp ~/build/LICENSE ./a3s-policy-enforcement/LICENSE
       - run: find .
       - run: dotnet restore
       - run: dotnet build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,9 @@ jobs:
   build-dotnet-libs:
     docker:
       - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
-    working_directory: ~/build
+    working_directory: ~/build/shared-libraries/resource-server-policy-enforcement/cs
     steps:
-      - checkout
-      - run: cd shared-libraries/resource-server-policy-enforcement/cs
+      - checkout ~/build
       - run: pwd; dotnet restore
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,14 @@ only-tags: &only-tags
     branches:
       ignore: /.*/
 
+only-lib-tags: &only-lib-tags
+  filters:
+    tags:
+      only: /^lib-.*/
+    branches:
+      ignore: /.*/
+
+
 # Orbs need to be enabled as a security setting. Third party orb access needs to be enabled by a circle CI admin.
 version: 2.1
 jobs:
@@ -302,3 +310,4 @@ workflows:
       - publish-dotnet-libs:
           requires:
           - build-dotnet-libs
+          <<: *only-lib-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - checkout:
           path: ~/build
-      - run: cp ~/build/LICENSE ./a3s-policy-enforcement/LICENSE
+      - run: cp ~/build/LICENSE ./a3s-policy-enforcement/LICENSE.txt
       - run: find .
       - run: dotnet restore
       - run: dotnet build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
           name: Retrieving build tag and setting in package
           command: |
               echo "Adding Build $CIRCLE_TAG to version"	             
-              export PKG_VERSION=${CIRCLE_TAG:-`date  +%Y.%M.%d.%H.%M.%S`}
+              export PKG_VERSION=${CIRCLE_TAG:-`date  +%Y.%M.%d.%H%M%S`}
               export THE_FILE=./a3s-policy-enforcement/a3s-policy-enforcement.csproj
               cp $THE_FILE $THE_FILE.old
               sed -i "s/XXX_VERSION_XXX/$PKG_VERSION/" $THE_FILE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,10 @@ workflows:
       - license-headers
       - postman-integration-tests
       - build-dotnet-libs
+      #testing in this location
+      - publish-dotnet-libs
+          requires:
+          - build-dotnet-libs
       - fossa-scan:
           filters:    
             branches:    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,10 +259,6 @@ workflows:
       - license-headers
       - postman-integration-tests
       - build-dotnet-libs
-      #testing in this location
-      - publish-dotnet-libs:
-          requires:
-          - build-dotnet-libs
       - fossa-scan:
           filters:    
             branches:    
@@ -303,3 +299,6 @@ workflows:
           - postman-integration-tests
           - generate-axios-client
           <<: *only-tags
+      - publish-dotnet-libs:
+          requires:
+          - build-dotnet-libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
       - checkout:
           path: ~/build
       - run: cp ~/build/LICENSE ./a3s-policy-enforcement
+      - run: find .
       - run: dotnet restore
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           at: ~/repo/workspace
       - run:
           command: 'pwd; find .'
-       - run:
+      - run:
           command: 'dotnet nuget push **/*.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json'     
   static-analysis:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
       - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
     working_directory: ~/build/shared-libraries/resource-server-policy-enforcement/cs
     steps:
-      - checkout ~/build
+      - checkout:
+        path: ~/build
       - run: pwd; dotnet restore
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,6 @@ only-tags: &only-tags
     branches:
       ignore: /.*/
 
-only-lib-tags: &only-lib-tags
-  filters:
-    tags:
-      only: /^lib-.*/
-    branches:
-      ignore: /.*/
-
 
 # Orbs need to be enabled as a security setting. Third party orb access needs to be enabled by a circle CI admin.
 version: 2.1
@@ -308,4 +301,4 @@ workflows:
       - publish-dotnet-libs:
           requires:
           - build-dotnet-libs
-          <<: *only-lib-tags
+          <<: *only-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,20 @@ jobs:
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       
       - run: dotnet pack
+      - persist_to_workspace:
+          root: ~/build/shared-libraries/resource-server-policy-enforcement
+          paths:
+            - cs
+  publish-dotnet-libs:
+    working_directory: ~/repo/workspace
+    docker:
+      - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
+    steps:
+      - attach_workspace:
+          at: ~/repo/workspace
+      - run:
+          command: 'pwd; find .'
+      
   static-analysis:
     docker:
       - image: newtmitch/sonar-scanner:alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,3 +312,4 @@ workflows:
           requires:
           - build-dotnet-libs
           <<: *only-tags
+          

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,8 @@ jobs:
           name: Retrieving build tag and setting in package
           command: |
               echo "Adding Build $CIRCLE_TAG to version"	             
-              export PKG_VERSION=${CIRCLE_TAG:-`date  +%Y.%M.%d-%H%M%S`}
+              export PKG_VERSION=${CIRCLE_TAG:-v0.0.1}
+              export PKG_VERSION=${PKG_VERSION/^v/}
               export THE_FILE=./a3s-policy-enforcement/a3s-policy-enforcement.csproj
               cp $THE_FILE $THE_FILE.old
               sed -i "s/XXX_VERSION_XXX/$PKG_VERSION/" $THE_FILE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
       - run: pwd; dotnet restore
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       
+      - run: dotnet pack
   static-analysis:
     docker:
       - image: newtmitch/sonar-scanner:alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
           name: Retrieving build tag and setting in package
           command: |
               echo "Adding Build $CIRCLE_TAG to version"	             
-              export PKG_VERSION=${CIRCLE_TAG:-`date  +%Y.%M.%d.%H%M%S`}
+              export PKG_VERSION=${CIRCLE_TAG:-`date  +%Y.%M.%d-%H%M%S`}
               export THE_FILE=./a3s-policy-enforcement/a3s-policy-enforcement.csproj
               cp $THE_FILE $THE_FILE.old
               sed -i "s/XXX_VERSION_XXX/$PKG_VERSION/" $THE_FILE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
               export THE_FILE=./a3s-policy-enforcement/a3s-policy-enforcement.csproj
               cp $THE_FILE $THE_FILE.old
               sed -i "s/XXX_VERSION_XXX/$PKG_VERSION/" $THE_FILE
-              diff $THE_FILE $THE_FILE.old
+              diff $THE_FILE $THE_FILE.old || true
       - run: dotnet restore
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
               export THE_FILE=./a3s-policy-enforcement/a3s-policy-enforcement.csproj
               cp $THE_FILE $THE_FILE.old
               sed -i "s/XXX_VERSION_XXX/$PKG_VERSION/" $THE_FILE
-              diff $THE_FILE $THE_FILE.old || true
+              diff  $THE_FILE.old $THE_FILE || true
       - run: dotnet restore
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     working_directory: ~/build/shared-libraries/resource-server-policy-enforcement/cs
     steps:
       - checkout:
-        path: ~/build
+          path: ~/build
       - run: pwd; dotnet restore
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,8 @@ jobs:
           at: ~/repo/workspace
       - run:
           command: 'pwd; find .'
-      
+       - run:
+          command: 'dotnet nuget push **/*.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json'     
   static-analysis:
     docker:
       - image: newtmitch/sonar-scanner:alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ jobs:
     steps:
       - checkout:
           path: ~/build
-      - run: pwd; dotnet restore
+      - run: cp ~/build/LICENSE ./a3s-policy-enforcement
+      - run: dotnet restore
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       
       - run: dotnet pack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
           name: Retrieving build tag and setting in package
           command: |
               echo "Adding Build $CIRCLE_TAG to version"	             
-              export PKG_VERSION=${CIRCLE_TAG:-`date  +%Y%M%d%H%M%S`}
+              export PKG_VERSION=${CIRCLE_TAG:-`date  +%Y.%M.%d.%H.%M.%S`}
               export THE_FILE=./a3s-policy-enforcement/a3s-policy-enforcement.csproj
               cp $THE_FILE $THE_FILE.old
               sed -i "s/XXX_VERSION_XXX/$PKG_VERSION/" $THE_FILE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
       - attach_workspace:
           at: ~/repo/workspace
       - run:
-          command: 'dotnet nuget push **/*.nupkg --no-symbol -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json'     
+          command: 'dotnet nuget push **/*.nupkg -n true -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json'     
 
   a3s-docker-build-push:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,11 @@ jobs:
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       
       - run: dotnet pack
       - persist_to_workspace:
-          root: ~/build/shared-libraries/resource-server-policy-enforcement
+          root: ~/build
           paths:
-            - cs
+            - shared-libraries/resource-server-policy-enforcement/cs
   publish-dotnet-libs:
-    working_directory: ~/repo/workspace
+    working_directory: ~/repo/workspace/shared-libraries/resource-server-policy-enforcement/cs
     docker:
       - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           command: |
               echo "Adding Build $CIRCLE_TAG to version"	             
               export PKG_VERSION=${CIRCLE_TAG:-v0.0.1}
-              export PKG_VERSION=${PKG_VERSION/^v/}
+              export PKG_VERSION=${PKG_VERSION/v/}
               export THE_FILE=./a3s-policy-enforcement/a3s-policy-enforcement.csproj
               cp $THE_FILE $THE_FILE.old
               sed -i "s/XXX_VERSION_XXX/$PKG_VERSION/" $THE_FILE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,15 @@ jobs:
       - checkout:
           path: ~/build
       - run: cp ~/build/LICENSE ./a3s-policy-enforcement/LICENSE.txt
+      - run: 
+          name: Retrieving build tag and setting in package
+          command: |
+              echo "Adding Build $CIRCLE_TAG to version"	             
+              export PKG_VERSION=${CIRCLE_TAG:-`date  +%Y%M%d%H%M%S`}
+              export THE_FILE=./a3s-policy-enforcement/a3s-policy-enforcement.csproj
+              cp $THE_FILE $THE_FILE.old
+              sed -i "s/XXX_VERSION_XXX/$PKG_VERSION/" $THE_FILE
+              diff $THE_FILE $THE_FILE.old
       - run: dotnet restore
       - run: dotnet build
       - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,34 +37,6 @@ jobs:
           root: ~/build
           paths:
             - tests/*
-  build-dotnet-libs:
-    docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
-    working_directory: ~/build/shared-libraries/resource-server-policy-enforcement/cs
-    steps:
-      - checkout:
-          path: ~/build
-      - run: cp ~/build/LICENSE ./a3s-policy-enforcement/LICENSE.txt
-      - run: find .
-      - run: dotnet restore
-      - run: dotnet build
-      - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       
-      - run: dotnet pack
-      - persist_to_workspace:
-          root: ~/build
-          paths:
-            - shared-libraries/resource-server-policy-enforcement/cs
-  publish-dotnet-libs:
-    working_directory: ~/repo/workspace/shared-libraries/resource-server-policy-enforcement/cs
-    docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
-    steps:
-      - attach_workspace:
-          at: ~/repo/workspace
-      - run:
-          command: 'pwd; find .'
-      - run:
-          command: 'dotnet nuget push **/*.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json'     
   static-analysis:
     docker:
       - image: newtmitch/sonar-scanner:alpine
@@ -183,6 +155,32 @@ jobs:
       - run: 
           name: Publish to NPM with Yarn.
           command: cd ~/repo/workspace/a3s-typescript-axios && yarn publish --access public
+
+  build-dotnet-libs:
+    docker:
+      - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
+    working_directory: ~/build/shared-libraries/resource-server-policy-enforcement/cs
+    steps:
+      - checkout:
+          path: ~/build
+      - run: cp ~/build/LICENSE ./a3s-policy-enforcement/LICENSE.txt
+      - run: dotnet restore
+      - run: dotnet build
+      - run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover       
+      - run: dotnet pack
+      - persist_to_workspace:
+          root: ~/build
+          paths:
+            - shared-libraries/resource-server-policy-enforcement/cs
+  publish-dotnet-libs:
+    working_directory: ~/repo/workspace/shared-libraries/resource-server-policy-enforcement/cs
+    docker:
+      - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
+    steps:
+      - attach_workspace:
+          at: ~/repo/workspace
+      - run:
+          command: 'dotnet nuget push **/*.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json'     
 
   a3s-docker-build-push:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ workflows:
       - postman-integration-tests
       - build-dotnet-libs
       #testing in this location
-      - publish-dotnet-libs
+      - publish-dotnet-libs:
           requires:
           - build-dotnet-libs
       - fossa-scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
       - attach_workspace:
           at: ~/repo/workspace
       - run:
-          command: 'dotnet nuget push **/*.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json'     
+          command: 'dotnet nuget push **/*.nupkg --no-symbol -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json'     
 
   a3s-docker-build-push:
     docker:

--- a/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
+++ b/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>a3s_policy_enforcement</RootNamespace>
     <PackageId>a3s-security-policy-enforcement</PackageId>
-    <Version>1.0.1-ci-test</Version>
+    <Version>XXX_VERSION_XXX</Version>
     <Company>Grindrod</Company>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>

--- a/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
+++ b/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
@@ -6,11 +6,11 @@
     <PackageId>a3s-security-policy-enforcement</PackageId>
     <Version>1.0.1</Version>
     <Company>Grindrod</Company>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
-    <None Include="LICENSE.txt" Pack="true" PackagePath="LICENSE"/>
+    <None Include="LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
   </ItemGroup>
 </Project>

--- a/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
+++ b/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
@@ -11,6 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
-    <None Include="./LICENSE" Pack="true" PackagePath="LICENSE"/>
+    <None Include="LICENSE.txt" Pack="true" PackagePath="LICENSE"/>
   </ItemGroup>
 </Project>

--- a/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
+++ b/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
@@ -11,6 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
-    <None Include="LICENSE" Pack="true" PackagePath="LICENSE"/>
+    <None Include="./LICENSE" Pack="true" PackagePath="LICENSE"/>
   </ItemGroup>
 </Project>

--- a/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
+++ b/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
@@ -11,6 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
-    <None Include="../../../../LICENSE" Pack="true" PackagePath="LICENSE"/>
+    <None Include="LICENSE" Pack="true" PackagePath="LICENSE"/>
   </ItemGroup>
 </Project>

--- a/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
+++ b/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>a3s_policy_enforcement</RootNamespace>
-    <PackageId>a3s-security-policy-enforcement</PackageId>
+    <PackageId>a3s-security-policy-enforcement-lib</PackageId>
     <Version>XXX_VERSION_XXX</Version>
     <Company>Grindrod</Company>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
+++ b/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>a3s_policy_enforcement</RootNamespace>
     <PackageId>a3s-security-policy-enforcement</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.1-ci-test</Version>
     <Company>Grindrod</Company>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>

--- a/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
+++ b/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
@@ -4,11 +4,13 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>a3s_policy_enforcement</RootNamespace>
     <PackageId>a3s-security-policy-enforcement</PackageId>
-	<Version>1.0.1</Version>
-	<Company>Grindrod</Company>
+    <Version>1.0.1</Version>
+    <Company>Grindrod</Company>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
+    <None Include="../../../../LICENSE" Pack="true" PackagePath="LICENSE"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds the CI capability to build the security Nuget package and to push to Nuget if a release is tagged.

It adds two workflow steps to build and to push the package.
 
Builds happen on all commits,  but pushing to Nuget only happens on correctly named tags.

**NOTES:**
* Trying to publish to an already published package version fails - by design: packages should be considered immutable.
* light-weight and annotated git tags fail on CircleCI - only Github releases work and are supported.
* Tags need to be named as valid [nuget versions](https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-basics) for publishing to succeed. To support `v`-s in names `v`-s are removed.