### PR TITLE
Upgrade a3s-policy-enforcement to dotNet Core 3 point 1

### DIFF
--- a/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
+++ b/shared-libraries/resource-server-policy-enforcement/cs/a3s-policy-enforcement/a3s-policy-enforcement.csproj
@@ -1,16 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>a3s_policy_enforcement</RootNamespace>
     <PackageId>a3s-security-policy-enforcement-lib</PackageId>
     <Version>XXX_VERSION_XXX</Version>
     <Company>Grindrod</Company>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <ReleaseVersion>1.1</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
-    <None Include="LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
+    <None Include="LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
 </Project>

--- a/shared-libraries/resource-server-policy-enforcement/cs/cs.sln
+++ b/shared-libraries/resource-server-policy-enforcement/cs/cs.sln
@@ -31,4 +31,7 @@ Global
 		{0252654A-3B87-4420-AC71-5287BC7E26E3}.Release|x86.ActiveCfg = Release|Any CPU
 		{0252654A-3B87-4420-AC71-5287BC7E26E3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		version = 1.1
+	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR upgrades the a3s-policy-enforcement project to .Net Core 3.1.

This fixes #107.