### PR TITLE
update refresh token on token refresh

### DIFF
--- a/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
+++ b/src/za.co.grindrodbank.a3s/Services/SecurityContractClientService.cs
@@ -62,6 +62,9 @@ namespace za.co.grindrodbank.a3s.Services
                 client.IdentityTokenLifetime = oauth2ClientSubmit.IdentityTokenLifetime;
             }
 
+            client.RefreshTokenExpiration = (int)TokenExpiration.Absolute;
+            client.RefreshTokenUsage = (int)TokenUsage.OneTimeOnly;
+
             ApplyClientAllowedScopes(client, oauth2ClientSubmit);
             ApplyClientAllowedGrantTypes(client, oauth2ClientSubmit);
             ApplyClientSecrets(client, oauth2ClientSubmit);


### PR DESCRIPTION
This PR ensures a new refresh token is sent on every token refresh request, to ensure the refresh token does not expire and require a fresh login.

These settings can later be implemented through the Client definition of the Security Contract if it is desired to be configurable.

This fixes #146. 