### PR TITLE
A3S Running Behind TLS Terminated Ingress -> Master

### DIFF
--- a/src/za.co.grindrodbank.a3s-identity-server/Startup.cs
+++ b/src/za.co.grindrodbank.a3s-identity-server/Startup.cs
@@ -28,6 +28,7 @@ using Newtonsoft.Json.Serialization;
 using System;
 using Microsoft.AspNetCore.Http;
 using za.co.grindrodbank.a3s.ConnectionClients;
+using Microsoft.AspNetCore.HttpOverrides;
 
 namespace za.co.grindrodbank.a3sidentityserver
 {
@@ -82,6 +83,16 @@ namespace za.co.grindrodbank.a3sidentityserver
                 iis.AutomaticAuthentication = false;
             });
 
+            // Configure the Identity Server to run behind a reverse proxy if configured.
+            if (Configuration.GetValue<bool>("RunningBehindReverseProxy"))
+            {
+                services.Configure<ForwardedHeadersOptions>(options =>
+                {
+                    options.ForwardedHeaders =
+                        ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                });
+            }
+
             services.AddIdentityServer(options =>
             {
                 options.Events.RaiseErrorEvents = true;
@@ -127,6 +138,22 @@ namespace za.co.grindrodbank.a3sidentityserver
         {
             // Configure cookie policy to cater for older user agents that do not support the new SameSite cookie property functionality
             app.UseCookiePolicy();
+
+            // Configure the Identity Server to run behind a reverse proxy if configured.
+            if (Configuration.GetValue<bool>("RunningBehindReverseProxy"))
+            {
+                app.UseForwardedHeaders();
+            }
+
+            // Configure the Identity Server to use HTTPS schema as it is running behind a TLS terminated Ingress.
+            if (Configuration.GetValue<bool>("RunningBehindTlsTermintedIngress"))
+            {
+                app.Use((context, next) =>
+                {
+                    context.Request.Scheme = "https";
+                    return next();
+                });
+            }
 
             if (Environment.IsDevelopment())
             {

--- a/src/za.co.grindrodbank.a3s-identity-server/appsettings.Development.json
+++ b/src/za.co.grindrodbank.a3s-identity-server/appsettings.Development.json
@@ -27,5 +27,7 @@
     "Username": "",
     "Password": "",
     "Signature": "<p>Regards</p><p><b>The A3S team</b></p>"
-  }
+  },
+  "RunningBehindReverseProxy": false,
+  "RunningBehindTlsTermintedIngress": false
 }

--- a/src/za.co.grindrodbank.a3s-identity-server/appsettings.json
+++ b/src/za.co.grindrodbank.a3s-identity-server/appsettings.json
@@ -21,6 +21,6 @@
     "LdapAdminKey": "this.secret.key.736",
     "UserTokenKey": "this.secret.key.736"
   },
-  "RunningBehindReverseProxy": true,
-  "RunningBehindTlsTermintedIngress": true
+  "RunningBehindReverseProxy": false,
+  "RunningBehindTlsTermintedIngress": false
 }

--- a/src/za.co.grindrodbank.a3s-identity-server/appsettings.json
+++ b/src/za.co.grindrodbank.a3s-identity-server/appsettings.json
@@ -20,5 +20,7 @@
   "EncryptionKeys": {
     "LdapAdminKey": "this.secret.key.736",
     "UserTokenKey": "this.secret.key.736"
-  }
+  },
+  "RunningBehindReverseProxy": true,
+  "RunningBehindTlsTermintedIngress": true
 }


### PR DESCRIPTION
Added additional configuration options that enable the Identity service to run behind a reverse proxy and to be able to generate HTTPS scheme discovery document URLs.

- Resolves #154 